### PR TITLE
Bump down version of org.apache.felix.scr.annotations from 1.9.6 to

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <version>1.9.6</version>
+            <version>1.6.0</version>
         </dependency>
         <!-- Spring Roo modules -->
         <dependency>
@@ -302,16 +302,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.2</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-scr-plugin</artifactId>
-                <version>1.20.0</version>
+                <version>1.7.2</version>
                 <executions>
                     <execution>
                         <id>generate-scr-scrdescriptor</id>


### PR DESCRIPTION
1.6.0.  Bump version of maven-compiler-plugin from 2.3.2 to 3.2 and set
the source and target java version to 1.6 from 1.5.  Bump down version
of maven-scr-plugin from 1.20.0 to 1.7.2 to address issue #9
